### PR TITLE
Additional I18n APIs.

### DIFF
--- a/src/main/java/fr/zcraft/zlib/components/i18n/I.java
+++ b/src/main/java/fr/zcraft/zlib/components/i18n/I.java
@@ -87,6 +87,16 @@ public class I
     {
         return I18n.translate(null, null, text, null, null, parameters);
     }
+    
+    public static String t(Locale locale, I18nText text, Object... parameters)
+    {
+        return I18n.translate(locale, text, parameters);
+    }
+    
+    public static String t(I18nText text, Object... parameters)
+    {
+        return t(null, text, parameters);
+    }
 
     /**
      * Translates the string with a plural.
@@ -305,4 +315,18 @@ public class I
         player.sendMessage(I18n.translate(I18n.getPlayerLocale(player), context, singular, plural, count, parameters));
     }
     
+    public static I18nText i(String messageId)
+    {
+        return i(messageId, null, null, null);
+    }
+    
+    public static I18nText i(String messageId, String pluralMessageId, Integer count)
+    {
+        return i(messageId, pluralMessageId, count, null);
+    }
+    
+    public static I18nText i(String messageId, String pluralMessageId, Integer count, String context)
+    {
+        return new I18nText(messageId, pluralMessageId, count, context);
+    }
 }

--- a/src/main/java/fr/zcraft/zlib/components/i18n/I18n.java
+++ b/src/main/java/fr/zcraft/zlib/components/i18n/I18n.java
@@ -647,6 +647,11 @@ public class I18n extends ZLibComponent
         return translate(null, context, messageId, messageIdPlural, count, parameters);
     }
     
+    public static String translate(Locale locale, I18nText text, Object... parameters)
+    {
+        return translate(null, text.getContext(), text.getMessageId(), text.getMessageId(), text.getCount(), parameters);
+    }
+    
     /**
      * Replaces some formatting codes into system codes.
      *

--- a/src/main/java/fr/zcraft/zlib/components/i18n/I18nText.java
+++ b/src/main/java/fr/zcraft/zlib/components/i18n/I18nText.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright or © or Copr. ZLib contributors (2015 - 2016)
+ *
+ * This software is governed by the CeCILL-B license under French law and
+ * abiding by the rules of distribution of free software.  You can  use,
+ * modify and/ or redistribute the software under the terms of the CeCILL-B
+ * license as circulated by CEA, CNRS and INRIA at the following URL
+ * "http://www.cecill.info".
+ *
+ * As a counterpart to the access to the source code and  rights to copy,
+ * modify and redistribute granted by the license, users are provided only
+ * with a limited warranty  and the software's author,  the holder of the
+ * economic rights,  and the successive licensors  have only  limited
+ * liability.
+ *
+ * In this respect, the user's attention is drawn to the risks associated
+ * with loading,  using,  modifying and/or developing or reproducing the
+ * software by the user in light of its specific status of free software,
+ * that may mean  that it is complicated to manipulate,  and  that  also
+ * therefore means  that it is reserved for developers  and  experienced
+ * professionals having in-depth computer knowledge. Users are therefore
+ * encouraged to load and test the software's suitability as regards their
+ * requirements in conditions enabling the security of their systems and/or
+ * data to be ensured and,  more generally, to use and operate it in the
+ * same conditions as regards security.
+ *
+ * The fact that you are presently reading this means that you have had
+ * knowledge of the CeCILL-B license and that you accept its terms.
+ */
+
+package fr.zcraft.zlib.components.i18n;
+
+public class I18nText
+{
+    private final String messageId;
+    private final String pluralMessageId;
+    private final Integer count;
+    private final String context;
+    
+    private Object[] parameters;
+    
+    public I18nText(String messageId, String pluralMessageId, Integer count, String context)
+    {
+        this.messageId = messageId;
+        this.pluralMessageId = pluralMessageId;
+        this.count = count;
+        this.context = context;
+    }
+    
+    public I18nText(String messageId)
+    {
+        this(messageId, null, null, null);
+    }
+
+    public String getMessageId()
+    {
+        return messageId;
+    }
+
+    public String getPluralMessageId()
+    {
+        return pluralMessageId;
+    }
+
+    public Integer getCount()
+    {
+        return count;
+    }
+    
+    public String getContext()
+    {
+        return context;
+    }
+
+    public Object[] getParameters()
+    {
+        return parameters;
+    }
+
+    public void setParameters(Object[] parameters)
+    {
+        this.parameters = parameters;
+    }
+}


### PR DESCRIPTION
The goal here is to separate translation data from runtime parameters, allowing `gettext` to detect tranlatable strings more reliably.

This is done by adding a new class, `I18nText` (name can be subject to change), holding only the information `gettext` needs, marking it with the `I.i()` method before passing it to `I.t()`. The other `I.t()` sets of methods will not be deprecated.

This also allows to defer the `I.t()` method call from the initial `I.i()` marking, allowing other APIs (such as GUI, Commands, ItemStackBuilder, RawTextBuilder …) to take `I18nText` objects instead of regular strings, allowing them to automatically select the appropriate locale for the targeted player, for instance.

The basic implementation is here, but the integration with the other APIs still needs to be done. Extra utility methods may also be added.