### PR TITLE
Configuration can be reloaded (and other fixes)

### DIFF
--- a/src/main/java/fr/zcraft/zlib/components/configuration/Configuration.java
+++ b/src/main/java/fr/zcraft/zlib/components/configuration/Configuration.java
@@ -34,6 +34,7 @@ import fr.zcraft.zlib.core.ZLib;
 import fr.zcraft.zlib.core.ZLibComponent;
 import fr.zcraft.zlib.tools.Callback;
 
+
 public abstract class Configuration extends ZLibComponent
 {
     /* ===== Static API ===== */
@@ -51,12 +52,30 @@ public abstract class Configuration extends ZLibComponent
         instance.init(configurationClass);
         instance.onEnable();
     }
-    
+
+    /**
+     * Saves the config.yml configuration to the disk.
+     */
     static public void save()
     {
-        ZLib.getPlugin().saveConfig();
+        instance.save(true);
     }
 
+    /**
+     * Reloads the config.yml configuration from the disk.
+     */
+    static public void reload()
+    {
+        instance.reload(true);
+    }
+
+    /**
+     * Registers a callback called when the configuration is updated someway.
+     *
+     * Callbacks are not called when the configuration is reloaded fully.
+     *
+     * @param callback The callback.
+     */
     static public void registerConfigurationUpdateCallback(Callback<ConfigurationItem<?>> callback)
     {
         instance.registerConfigurationUpdateCallback(callback);

--- a/src/main/java/fr/zcraft/zlib/components/configuration/ConfigurationInstance.java
+++ b/src/main/java/fr/zcraft/zlib/components/configuration/ConfigurationInstance.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 
+
 public class ConfigurationInstance extends ZLibComponent
 {
     private ConfigurationItem[] items;
@@ -118,7 +119,23 @@ public class ConfigurationInstance extends ZLibComponent
     
     public void save()
     {
-        ZLib.getPlugin().saveConfig();
+        final File saveTo = file != null ? file : (fileName != null ? new File(ZLib.getPlugin().getDataFolder().getAbsolutePath() + "/" + fileName) : null);
+
+        if (saveTo != null)
+        {
+            try
+            {
+                this.getConfig().save(saveTo);
+            }
+            catch (final IOException e)
+            {
+                PluginLogger.error("Could not save config to {0}", e, saveTo);
+            }
+        }
+        else
+        {
+            ZLib.getPlugin().saveConfig();
+        }
     }
     
     public FileConfiguration getConfig()

--- a/src/main/java/fr/zcraft/zlib/components/configuration/ConfigurationInstance.java
+++ b/src/main/java/fr/zcraft/zlib/components/configuration/ConfigurationInstance.java
@@ -24,45 +24,150 @@ public class ConfigurationInstance extends ZLibComponent
 {
     private ConfigurationItem[] items;
     private Callback<ConfigurationItem<?>> updateCallback;
-    private final FileConfiguration bukkitConfiguration;
+    private FileConfiguration bukkitConfiguration;
     private final String fileName;
     private final File file;
-    
+
+    /**
+     * Creates a configuration instance from a file.
+     * @param file The file containing the YAML configuration.
+     */
     public ConfigurationInstance(File file)
     {
         this.file = file;
         this.fileName = null;
         this.bukkitConfiguration = new YamlConfiguration();
     }
-    
+
+    /**
+     * Creates a configuration instance from a file.
+     * @param fileName The name, relative to the plugin's data folder, of the
+     *                 file containing the YAML configuration.
+     */
     public ConfigurationInstance(String fileName)
     {
         this.file = null;
         this.fileName = fileName;
         this.bukkitConfiguration = new YamlConfiguration();
     }
-    
+
+    /**
+     * Creates a configuration instance from a {@link FileConfiguration} directly.
+     * @param config The configuration.
+     */
     ConfigurationInstance(FileConfiguration config)
     {
         this.bukkitConfiguration = config;
         this.file = null;
         this.fileName = null;
     }
-    
+
+    /**
+     * Initializes and loads the configuration.
+     *
+     * @throws IOException If the configuration is loaded from a file and this file
+     * cannot be opened for some reason.
+     * @throws InvalidConfigurationException If the configuration is invalid.
+     */
     public void load() throws IOException, InvalidConfigurationException
     {
         init(this.getClass());
 
-        if (file != null)
-        {
-            this.bukkitConfiguration.load(file);
-        }
-        else if (fileName != null)
-        {
-            this.bukkitConfiguration.load(ZLib.getPlugin().getDataFolder().getAbsolutePath() + "/" + fileName);
-        }
+        final File underlyingFile = getUnderlyingFile();
 
-        if(!validate())
+        if (underlyingFile != null)
+        {
+            bukkitConfiguration.load(underlyingFile);
+        }
+        // Else the configuration is already “loaded” as the configuration instance was
+        // directly constructed with a FileConfiguration instance.
+
+        validateVerbally();
+    }
+
+    /**
+     * Reloads the configuration from its file.
+     *
+     * @throws IllegalStateException If the configuration was directly constructed from
+     * a {@link FileConfiguration}, as there is nothing to reload the configuration from.
+     */
+    public void reload() throws IllegalStateException
+    {
+        reload(false);
+    }
+
+    /**
+     * Reloads the configuration from its file.
+     *
+     * @param assumeConfigYML If {@code true}, and the configuration was loaded from a
+     *                        {@link FileConfiguration} directly, we assume that we have
+     *                        to reload the main plugin configuration from config.yml,
+     *                        as this configuration is loaded directly. This option is
+     *                        used internally in {@link Configuration} for the reload method.
+     * @throws IllegalStateException If the configuration was directly constructed from
+     * a {@link FileConfiguration}, and {@code assumeConfigYML} is false, as there is nothing
+     * to reload the configuration from.
+     */
+    void reload(boolean assumeConfigYML) throws IllegalStateException
+    {
+        try
+        {
+            final File underlyingFile = getUnderlyingFile();
+
+            if (underlyingFile != null)
+            {
+                this.bukkitConfiguration.load(underlyingFile);
+            }
+            else if (assumeConfigYML)
+            {
+                // We assume that it's config.yml
+                ZLib.getPlugin().reloadConfig();
+
+                // The instance change when the reloadConfig method is called.
+                this.bukkitConfiguration = ZLib.getPlugin().getConfig();
+            }
+            else
+            {
+                throw new IllegalStateException("Cannot reload configuration if constructed directly from a FileConfiguration instance.");
+            }
+
+            validateVerbally();
+        }
+        catch(Exception ex)
+        {
+            PluginLogger.error("Couldn't read configuration file {0}: {1}", ex, getFilePath(), ex.getMessage());
+        }
+    }
+
+    /**
+     * @return The file path, or {@code null} if no file name is set. This may return a
+     * relative path to the plugin's data folder.
+     *
+     * @see #getUnderlyingFile() Method to get a {@code File} object directly, without
+     * path problems.
+     */
+    public String getFilePath()
+    {
+        if(file != null) return file.getAbsolutePath();
+        return fileName;
+    }
+
+    /**
+     * @return A {@link File} object pointing to the underlying file, or {@code null} if no
+     * file name is set. This assumes that the file name is relative to the plugin's data folder.
+     */
+    private File getUnderlyingFile()
+    {
+        if (file == null && fileName == null) return null;
+        return file != null ? file : new File(ZLib.getPlugin().getDataFolder().getAbsolutePath() + "/" + fileName);
+    }
+
+    /**
+     * Validates then prints error messages if it does not actually validates.
+     */
+    private void validateVerbally()
+    {
+        if (!validate())
         {
             // The file path is null when the instance was constructed from a FileConfiguration object directly.
             final String filePath = getFilePath();
@@ -74,12 +179,6 @@ public class ConfigurationInstance extends ZLibComponent
         }
     }
     
-    public String getFilePath()
-    {
-        if(file != null) return file.getAbsolutePath();
-        return fileName;
-    }
-    
     @Override
     protected void onEnable() 
     {
@@ -89,7 +188,7 @@ public class ConfigurationInstance extends ZLibComponent
         }
         catch(Exception ex)
         {
-            PluginLogger.error("Couldn't read configuration file {0} : {1}", ex, getFilePath(), ex.getMessage());
+            PluginLogger.error("Couldn't read configuration file {0}: {1}", ex, getFilePath(), ex.getMessage());
         }
     }
     
@@ -109,17 +208,40 @@ public class ConfigurationInstance extends ZLibComponent
                     item.setInstance(this);
                     itemsList.add(item);
                 }
-                catch(Exception ex){}
+                catch (Exception ignored) {}
             }
         }
         
         items = itemsList.toArray(new ConfigurationItem[itemsList.size()]);
         initFields();
     }
-    
-    public void save()
+
+    /**
+     * Saves the configuration to the disk.
+     *
+     * @throws IllegalStateException If the configuration was directly constructed from
+     * a {@link FileConfiguration}, as there is nothing to save the configuration to.
+     */
+    public void save() throws IllegalStateException
     {
-        final File saveTo = file != null ? file : (fileName != null ? new File(ZLib.getPlugin().getDataFolder().getAbsolutePath() + "/" + fileName) : null);
+        save(false);
+    }
+
+    /**
+     * Saves the configuration to the disk.
+     *
+     * @param assumeConfigYML If {@code true}, and the configuration was loaded from a
+     *                        {@link FileConfiguration} directly, we assume that we have
+     *                        to save the main plugin configuration to config.yml,
+     *                        as this configuration is loaded directly. This option is
+     *                        used internally in {@link Configuration} for the save method.
+     * @throws IllegalStateException If the configuration was directly constructed from
+     * a {@link FileConfiguration}, and {@code assumeConfigYML} is false, as there is nothing
+     * to save the configuration to.
+     */
+    void save(boolean assumeConfigYML) throws IllegalStateException
+    {
+        final File saveTo = getUnderlyingFile();
 
         if (saveTo != null)
         {
@@ -132,17 +254,31 @@ public class ConfigurationInstance extends ZLibComponent
                 PluginLogger.error("Could not save config to {0}", e, saveTo);
             }
         }
-        else
+        else if (assumeConfigYML)
         {
             ZLib.getPlugin().saveConfig();
         }
+        else
+        {
+            throw new IllegalStateException("Cannot save configuration if constructed directly from a FileConfiguration instance.");
+        }
     }
-    
+
+    /**
+     * @return The underlying configuration object.
+     */
     public FileConfiguration getConfig()
     {
         return bukkitConfiguration;
     }
 
+    /**
+     * Registers a callback called when the configuration is updated someway.
+     *
+     * Callbacks are not called when the configuration is reloaded fully.
+     *
+     * @param callback The callback.
+     */
     public void registerConfigurationUpdateCallback(Callback<ConfigurationItem<?>> callback)
     {
         updateCallback = callback;
@@ -155,7 +291,11 @@ public class ConfigurationInstance extends ZLibComponent
             configField.init();
         }
     }
-    
+
+    /**
+     * Checks if the configuration is valid.
+     * @return validity.
+     */
     private boolean validate()
     {
         boolean isValid = true;
@@ -169,6 +309,10 @@ public class ConfigurationInstance extends ZLibComponent
         return isValid;
     }
 
+    /**
+     * Calls an update callback for the given configuration item.
+     * @param configurationItem The updated configuration item.
+     */
     void triggerCallback(ConfigurationItem<?> configurationItem)
     {
         if (updateCallback != null) updateCallback.call(configurationItem);


### PR DESCRIPTION
* The configurations can be reloaded (except if non-internally constructed from a `FileConfiguration` as there is nothing to reload from in these cases — but one cannot create a configuration like
this without reflection anyway).
* Fixed save for configurations created from other files than `config.yml`.
* Added Javadoc.